### PR TITLE
mnt: made transform have same interface added test

### DIFF
--- a/sisl/physics/tests/test_physics_sparse.py
+++ b/sisl/physics/tests/test_physics_sparse.py
@@ -245,223 +245,249 @@ def test_sparse_orbital_transform_ortho_unpolarized():
     a = np.arange(M.spin.spins) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
     assert np.abs(Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
     assert np.abs(Mt.tocsr(-1)).sum() == 0
+
 
 def test_sparse_orbital_transform_nonortho_unpolarized():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='unpolarized', orthogonal=False)
     a = np.arange(M.spin.spins + 1) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(0) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
+
 
 def test_sparse_orbital_transform_ortho_polarized():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='polarized')
     a = np.arange(M.spin.spins) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(0.5 * M.tocsr(0) + 0.5 * M.tocsr(1) - Mt.tocsr(0)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(0.5 * Mcsr[0] + 0.5 * Mcsr[1] - Mt.tocsr(0)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
     assert np.abs(Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
     assert np.abs(Mt.tocsr(-1)).sum() == 0
+
 
 def test_sparse_orbital_transform_ortho_nc():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='non-colinear')
     a = np.arange(M.spin.spins) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(0.5 * M.tocsr(0) + 0.5 * M.tocsr(1) - Mt.tocsr(0)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(0.5 * Mcsr[0] + 0.5 * Mcsr[1] - Mt.tocsr(0)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
+
 
 def test_sparse_orbital_transform_ortho_so():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='so')
     a = np.arange(M.spin.spins) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(0.5 * M.tocsr(0) + 0.5 * M.tocsr(1) - Mt.tocsr(0)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(0.5 * Mcsr[0] + 0.5 * Mcsr[1] - Mt.tocsr(0)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
+
 
 def test_sparse_orbital_transform_nonortho_so():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='so', orthogonal=False)
     a = np.arange(M.spin.spins + 1) + 0.3
     M.construct(([0.1, 1.44], [a, a + 0.1]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
-    Mt = M.transform('unpolarized')
-    assert np.abs(0.5 * M.tocsr(0) + 0.5 * M.tocsr(1) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='unpolarized')
+    assert np.abs(0.5 * Mcsr[0] + 0.5 * Mcsr[1] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('polarized')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='polarized')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('non-colinear')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='non-colinear')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('so')
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(2) - Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(3) - Mt.tocsr(3)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    Mt = M.transform(spin='so')
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[2] - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[3] - Mt.tocsr(3)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
+
 
 def test_sparse_orbital_transform_basis():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='polarized', orthogonal=False)
     M.construct(([0.1, 1.44], [(3., 2., 1.), (0.3, 0.2, 0.)]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
     Mt = M.transform(orthogonal=True).transform(orthogonal=False)
     assert M.dim == Mt.dim
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
+
 
 def test_sparse_orbital_transform_combinations():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='polarized', orthogonal=False, dtype=np.int32)
     M.construct(([0.1, 1.44], [(3, 2, 1), (2, 1, 0)]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
     Mt = M.transform(spin='non-colinear', dtype=np.float64, orthogonal=True).transform(spin='polarized', orthogonal=False)
     assert M.dim == Mt.dim
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
     Mt = M.transform(dtype=np.float128, orthogonal=True).transform(spin='so', dtype=np.float64, orthogonal=False)
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
     Mt = M.transform(spin='polarized', orthogonal=True).transform(spin='so', dtype=np.float64, orthogonal=False)
-    assert np.abs(M.tocsr(0) - Mt.tocsr(0)).sum() == 0
-    assert np.abs(M.tocsr(1) - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[0] - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[1] - Mt.tocsr(1)).sum() == 0
     assert np.abs(Mt.tocsr(2)).sum() == 0
-    assert np.abs(M.tocsr(-1) - Mt.tocsr(-1)).sum() == 0
+    assert np.abs(Mcsr[-1] - Mt.tocsr(-1)).sum() == 0
 
-    Mt = M.transform('unpolarized', dtype=np.float32, orthogonal=True).transform(dtype=np.complex128, orthogonal=False)
-    assert np.abs(0.5 * M.tocsr(0) + 0.5 * M.tocsr(1) - Mt.tocsr(0)).sum() == 0
+    Mt = M.transform(spin='unpolarized', dtype=np.float32, orthogonal=True).transform(dtype=np.complex128, orthogonal=False)
+    assert np.abs(0.5 * Mcsr[0] + 0.5 * Mcsr[1] - Mt.tocsr(0)).sum() == 0
+
 
 def test_sparse_orbital_transform_matrix():
     M = SparseOrbitalBZSpin(geom.graphene(), spin='polarized', orthogonal=False, dtype=np.int32)
     M.construct(([0.1, 1.44], [(1, 2, 3), (4, 5, 6)]))
     M.finalize()
+    Mcsr = [M.tocsr(i) for i in range(M.shape[2])]
 
     Mt = M.transform(spin='unpolarized', matrix=np.ones((1, 3)), orthogonal=True)
     assert Mt.dim == 1
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(0)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(0)).sum() == 0
 
     Mt = M.transform(spin='polarized', matrix=np.ones((2, 3)), orthogonal=True)
     assert Mt.dim == 2
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(1)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(1)).sum() == 0
 
     Mt = M.transform(matrix=np.ones((3, 3)), dtype=np.float64)
     assert Mt.dim == 3
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(2)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(2)).sum() == 0
 
     Mt = M.transform(spin='non-colinear', matrix=np.ones((4, 3)), orthogonal=True, dtype=np.float64)
     assert Mt.dim == 4
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(3)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(3)).sum() == 0
 
     Mt = M.transform(spin='non-colinear', matrix=np.ones((5, 3)), dtype=np.float64)
     assert Mt.dim == 5
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(4)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(4)).sum() == 0
 
     Mt = M.transform(spin='so', matrix=np.ones((8, 3)), orthogonal=True, dtype=np.float64)
     assert Mt.dim == 8
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(7)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(7)).sum() == 0
 
     Mt = M.transform(spin='so', matrix=np.ones((9, 3)), dtype=np.float64)
     assert Mt.dim == 9
-    assert np.abs(M.tocsr(0) + M.tocsr(1) + M.tocsr(2) - Mt.tocsr(8)).sum() == 0
+    assert np.abs(Mcsr[0] + Mcsr[1] + Mcsr[2] - Mt.tocsr(8)).sum() == 0
+
+
+def test_sparse_orbital_transform_fail():
+    M = SparseOrbitalBZSpin(geom.graphene(), spin='polarized', orthogonal=False, dtype=np.int32)
+    M.construct(([0.1, 1.44], [(1, 2, 3), (4, 5, 6)]))
+    M.finalize()
+
+    with pytest.raises(ValueError):
+        M.transform(np.zeros([2, 2]), spin='unpolarized')

--- a/sisl/sparse.py
+++ b/sisl/sparse.py
@@ -1378,7 +1378,12 @@ class SparseCSR(NDArrayOperatorsMixin):
                           shape=shape, **kwargs)
 
     def transform(self, matrix, dtype=None):
-        r""" Apply a linear transformation :math:`R^n \rightarrow R^m` to the :math:`n`-dimensional elements of the sparse matrix.
+        r""" Apply a linear transformation :math:`R^n \rightarrow R^m` to the :math:`n`-dimensional elements of the sparse matrix
+
+        Notes
+        -----
+        The transformation matrix does *not* act on the rows and columns, only on the
+        final dimension of the matrix.
 
         Parameters
         ----------
@@ -1391,6 +1396,11 @@ class SparseCSR(NDArrayOperatorsMixin):
 
         if dtype is None:
             dtype = np.find_common_type([self.dtype, matrix.dtype], [])
+
+        if matrix.shape[1] != self.shape[2]:
+            raise ValueError(f"{self.__class__.__name__}.transform incompatible "
+                             f"transformation matrix and spin dimensions: "
+                             f"matrix.shape={matrix.shape} and self.spin={N} ; out.spin={M}")
 
         # set dimension of new sparse matrix
         new_dim = len(matrix)

--- a/sisl/tests/test_sparse.py
+++ b/sisl/tests/test_sparse.py
@@ -1329,6 +1329,7 @@ def test_transform1():
     assert conv.shape[2] == len(matrix)
     assert np.abs(conv.tocsr(0) - 0.3 * csr1 - 0.7 * csr2).sum() == 0.
 
+
 def test_transform2():
     csr1 = sc.sparse.random(10, 100, 0.01, random_state=24812)
     csr2 = sc.sparse.random(10, 100, 0.02, random_state=24813)
@@ -1342,6 +1343,7 @@ def test_transform2():
     assert conv.shape[2] == len(matrix)
     assert np.abs(conv.tocsr(0) - 0.3 * csr1).sum() == 0.
     assert np.abs(conv.tocsr(1) - 0.7 * csr2).sum() == 0.
+
 
 def test_transform3():
     csr1 = sc.sparse.random(10, 100, 0.01, random_state=24812)
@@ -1357,6 +1359,7 @@ def test_transform3():
     assert np.abs(conv.tocsr(0) - 0.3 * csr1).sum() == 0.
     assert np.abs(conv.tocsr(1) - 0.7 * csr2).sum() == 0.
     assert np.abs(conv.tocsr(2) - 0.1 * csr1 - 0.2 * csr2).sum() == 0.
+
 
 def test_transform4():
     csr1 = sc.sparse.random(10, 100, 0.01, random_state=24812)


### PR DESCRIPTION
Since the SparseCSR has a specific interface, I have amended
them to be the same.

Also added a test to ensure it fails for wrong arguments.

Made the tests a bit faster by doing the tocsr once.

Could you also amend the `CHANGELOG` to highlight its implementation (and reference the pull-request #320)

Thanks!