### PR TITLE
mnt: fixed and simplified some logic in the read_multiple function

### DIFF
--- a/sisl/io/siesta/ani.py
+++ b/sisl/io/siesta/ani.py
@@ -8,11 +8,15 @@ from ..xyz import xyzSile
 from ..sile import add_sile
 from sisl._internal import set_module
 
+
 __all__ = ["aniSileSiesta"]
+
 
 @set_module("sisl.io.siesta")
 class aniSileSiesta(xyzSile):
 
-    pass
+    def read_geometry(*args, all=True, **kwargs):
+        return super().read_geometry(*args, all=all, **kwargs)
 
-add_sile('ani', aniSileSiesta, case=False, gzip=True)
+
+add_sile('ANI', aniSileSiesta, gzip=True)

--- a/sisl/io/siesta/struct.py
+++ b/sisl/io/siesta/struct.py
@@ -10,6 +10,7 @@ from sisl._internal import set_module
 from sisl import Geometry, Atom, AtomGhost, AtomUnknown, Atoms, SuperCell
 from sisl.unit.siesta import unit_convert
 
+
 __all__ = ['structSileSiesta']
 
 

--- a/sisl/io/tests/test_xyz.py
+++ b/sisl/io/tests/test_xyz.py
@@ -106,3 +106,5 @@ C   2.00000  0.00000000  0.00000000
     assert g[0].na == 1 and g[-1].na == 3
     g = xyzSile(f).read_geometry(stop=2, step=1)
     assert g[0].na == 1 and g[-1].na == 2
+
+    g = xyzSile(f).read_geometry(sc=None, atoms=None)

--- a/sisl/io/xyz.py
+++ b/sisl/io/xyz.py
@@ -87,8 +87,21 @@ class xyzSile(Sile):
             sc = SuperCell(cell, nsc=[1] * 3)
         return Geometry(xyz, atoms=sp, sc=sc)
 
+    def _r_geometry_skip(self, *args, **kwargs):
+        """ Read the geometry for a generic xyz file (not sisl, nor ASE) """
+        # The cell dimensions isn't defined, we are going to create a molecule box
+        line = self.readline()
+        if line == '':
+            return None
+
+        na = int(line)
+        self.readline()
+        for _ in range(na):
+            self.readline()
+        return na
+
     @sile_fh_open()
-    @sile_read_multiple()
+    @sile_read_multiple(skip_call=_r_geometry_skip)
     def read_geometry(self, atoms=None, sc=None):
         """ Returns Geometry object from the XYZ file
 
@@ -102,6 +115,7 @@ class xyzSile(Sile):
         line = self.readline()
         if line == '':
             return None
+
         # Read number of atoms
         na = int(line)
 


### PR DESCRIPTION
It should now be able to handle more cases and more easily transfer data to a required data-structure.

Added an xyz skip function which is much faster than the read_geometry call.

Changed default all=True for the ANI file.
Changed the suffix for ANI files to be capitalized.

Added a postprocess function for post-processing the data returned by the read_multiple function. This would enable one to merge stuff etc.